### PR TITLE
Fix libc-bin downgrade issue in Dockerfile for CI/CD

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,17 +9,18 @@ ENV PYTHONUNBUFFERED=1 \
     PIP_DISABLE_PIP_VERSION_CHECK=on \
     QR_CODE_DIR=/myapp/qr_codes
 
+# Set the working directory
 WORKDIR /myapp
 
 # Update system and specifically upgrade libc-bin to the required security patch version
 RUN apt-get update && apt-get install -y --no-install-recommends \
     gcc \
     libpq-dev \
-    && apt-get install -y libc-bin=2.36-9+deb12u7 \
+    && apt-get install -y --allow-downgrades libc-bin=2.36-9+deb12u7 \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-# Install Python dependencies in /.venv
+# Install Python dependencies into /.venv
 COPY requirements.txt .
 RUN python -m venv /.venv \
     && . /.venv/bin/activate \
@@ -30,7 +31,8 @@ RUN python -m venv /.venv \
 FROM python:3.12-slim-bookworm as final
 
 # Upgrade libc-bin in the final stage to ensure security patch is applied
-RUN apt-get update && apt-get install -y libc-bin=2.36-9+deb12u7 \
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    && apt-get install -y --allow-downgrades libc-bin=2.36-9+deb12u7 \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Updated Dockerfile to include --allow-downgrades flag during libc-bin installation in both build stages. This resolves apt-get downgrade error and ensures security patches are applied correctly. Workflow expected to pass after this fix.